### PR TITLE
367 : fixing git tag remote remove

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -60363,7 +60363,8 @@ const exec = async (command, args, options) => {
     ps.on('close', (exitCode) => {
       exec_log.info({command: `${command} ${args.join(' ')}`, stdout, stderr, exitCode, options}, 'exec command finished');
       if (exitCode !== 0 && options.noThrow === false) {
-        core.setFailed(`Failed to run command: ${command} '${args.join("', '")}'`);
+        core.warning(`Failed to run command: ${command} '${args.join("', '")}'`);
+        exec_log.warn({command, args, options, stdout, stderr, exitCode}, 'Command failed');
       }
       resolve({stdout, stderr, exitCode});
     });
@@ -60573,9 +60574,7 @@ const tag = {
    */
   existsRemote: async (tagName, remote = 'origin') => {
     try {
-      const {stdout} = await exec('git', ['ls-remote', '--tags', remote, `refs/tags/${tagName}`], {
-        noThrow: true,
-      });
+      const {stdout} = await exec('git', ['ls-remote', '--tags', remote, `refs/tags/${tagName}`]);
       return stdout.trim().includes(`refs/tags/${tagName}`);
     } catch (err) {
       git_log.warn({tagName, remote, err}, 'Failed to check if remote tag exists');
@@ -60634,11 +60633,11 @@ const tag = {
 
     // Also try to delete the tag from remote
     try {
-      await exec('git', ['fetch'], {noThrow: true});
+      await exec('git', ['fetch']);
       const remoteTagExists = await tag.existsRemote(tagName);
 
       if (remoteTagExists) {
-        const {exitCode} = await exec('git', ['push', 'origin', '--delete', tagName], {noThrow: true});
+        const {exitCode} = await exec('git', ['push', 'origin', '--delete', tagName]);
         if (exitCode === 0) {
           git_log.info({tagName}, infoRemoteTagDeleted);
         } else {

--- a/dist/index.js
+++ b/dist/index.js
@@ -60604,7 +60604,7 @@ const tag = {
   },
 
   /**
-   * Delete an existing Tag from the repository.
+   * Delete an existing Tag from the repository (both local and remote).
    *
    * @param {string} tagName
    * @returns {Promise<void>}
@@ -60613,10 +60613,15 @@ const tag = {
     await exec('git', ['tag', '-d', tagName]);
     git_log.info({tagName}, infoTagDeleted);
 
-    // TODO: Remote tag deletion is optional and might not be necessary
-    // // Also try to delete it from remote
-    //   await exec('git', ['push', 'origin', `:refs/tags/${tagName}`]);
-    //   log.info({tagName}, infoRemoteTagDeleted);
+    // Also try to delete the tag from remote
+    try {
+      for (const args of [['fetch'], ['push', 'origin', '--delete', tagName]]) {
+        await exec('git', args, {noThrow: true});
+      }
+      git_log.info({tagName}, infoRemoteTagDeleted);
+    } catch (err) {
+      git_log.warn({tagName, err}, warnCouldNotRemoveRemoteTag);
+    }
   },
 };
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -60614,12 +60614,11 @@ const tag = {
     git_log.info({tagName}, infoTagDeleted);
 
     // Also try to delete the tag from remote
-    try {
-      for (const args of [['fetch'], ['push', 'origin', '--delete', tagName]]) {
-        await exec('git', args, {noThrow: true});
-      }
+    await exec('git', ['fetch']);
+    const {exitCode} = await exec('git', ['push', 'origin', '--delete', tagName]);
+    if (exitCode === 0) {
       git_log.info({tagName}, infoRemoteTagDeleted);
-    } catch (err) {
+    } else {
       git_log.warn({tagName, err}, warnCouldNotRemoveRemoteTag);
     }
   },

--- a/dist/index.js
+++ b/dist/index.js
@@ -60554,7 +60554,7 @@ const tag = {
   },
 
   /**
-   * Test if a tag exists in the repository.
+   * Test if a tag exists locally in the repository.
    *
    * @param {string} tagName
    * @returns {Promise<boolean>}
@@ -60562,6 +60562,25 @@ const tag = {
   exists: async (tagName) => {
     const {stdout} = await exec('git', ['tag', '-l', tagName]);
     return stdout.trim() === tagName;
+  },
+
+  /**
+   * Test if a tag exists on the remote repository.
+   *
+   * @param {string} tagName
+   * @param {string} [remote='origin'] - Remote name to check
+   * @returns {Promise<boolean>}
+   */
+  existsRemote: async (tagName, remote = 'origin') => {
+    try {
+      const {stdout} = await exec('git', ['ls-remote', '--tags', remote, `refs/tags/${tagName}`], {
+        noThrow: true,
+      });
+      return stdout.trim().includes(`refs/tags/${tagName}`);
+    } catch (err) {
+      git_log.warn({tagName, remote, err}, 'Failed to check if remote tag exists');
+      return false;
+    }
   },
 
   /**
@@ -60614,11 +60633,21 @@ const tag = {
     git_log.info({tagName}, infoTagDeleted);
 
     // Also try to delete the tag from remote
-    await exec('git', ['fetch']);
-    const {exitCode} = await exec('git', ['push', 'origin', '--delete', tagName]);
-    if (exitCode === 0) {
-      git_log.info({tagName}, infoRemoteTagDeleted);
-    } else {
+    try {
+      await exec('git', ['fetch'], {noThrow: true});
+      const remoteTagExists = await tag.existsRemote(tagName);
+
+      if (remoteTagExists) {
+        const {exitCode} = await exec('git', ['push', 'origin', '--delete', tagName], {noThrow: true});
+        if (exitCode === 0) {
+          git_log.info({tagName}, infoRemoteTagDeleted);
+        } else {
+          git_log.warn({tagName}, warnCouldNotRemoveRemoteTag);
+        }
+      } else {
+        git_log.info({tagName}, 'Remote tag does not exist, skipping remote deletion');
+      }
+    } catch (err) {
       git_log.warn({tagName, err}, warnCouldNotRemoveRemoteTag);
     }
   },

--- a/dist/index.js
+++ b/dist/index.js
@@ -60350,7 +60350,7 @@ const exec = async (command, args, options) => {
     },
   };
 
-  return new Promise((resolve) => {
+  return new Promise((resolve, reject) => {
     const ps = external_node_child_process_namespaceObject.spawn(command, args, options);
     let stdout = '';
     let stderr = '';
@@ -60363,8 +60363,11 @@ const exec = async (command, args, options) => {
     ps.on('close', (exitCode) => {
       exec_log.info({command: `${command} ${args.join(' ')}`, stdout, stderr, exitCode, options}, 'exec command finished');
       if (exitCode !== 0 && options.noThrow === false) {
-        core.warning(`Failed to run command: ${command} '${args.join("', '")}'`);
-        exec_log.warn({command, args, options, stdout, stderr, exitCode}, 'Command failed');
+        const errorMessage = `Failed to run command: ${command} '${args.join("', '")}' with exit code ${exitCode}`;
+        core.warning(errorMessage);
+        exec_log.warn({command, args, options, stdout, stderr, exitCode}, errorMessage);
+        // TODO: still not sure whether to reject when exec is failing; I would rather have the caller handle it
+        // return reject(errorMessage);
       }
       resolve({stdout, stderr, exitCode});
     });

--- a/src/utils/exec.js
+++ b/src/utils/exec.js
@@ -28,7 +28,7 @@ export const exec = async (command, args, options) => {
     },
   };
 
-  return new Promise((resolve) => {
+  return new Promise((resolve, reject) => {
     const ps = cp.spawn(command, args, options);
     let stdout = '';
     let stderr = '';
@@ -41,8 +41,11 @@ export const exec = async (command, args, options) => {
     ps.on('close', (exitCode) => {
       log.info({command: `${command} ${args.join(' ')}`, stdout, stderr, exitCode, options}, 'exec command finished');
       if (exitCode !== 0 && options.noThrow === false) {
-        core.warning(`Failed to run command: ${command} '${args.join("', '")}'`);
-        log.warn({command, args, options, stdout, stderr, exitCode}, 'Command failed');
+        const errorMessage = `Failed to run command: ${command} '${args.join("', '")}' with exit code ${exitCode}`;
+        core.warning(errorMessage);
+        log.warn({command, args, options, stdout, stderr, exitCode}, errorMessage);
+        // TODO: still not sure whether to reject when exec is failing; I would rather have the caller handle it
+        // return reject(errorMessage);
       }
       resolve({stdout, stderr, exitCode});
     });

--- a/src/utils/exec.js
+++ b/src/utils/exec.js
@@ -1,7 +1,7 @@
-import cp from 'node:child_process';
 import core from '@actions/core';
-import {logger} from './logging.js';
+import cp from 'node:child_process';
 import {projectName} from '../constants.js';
+import {logger} from './logging.js';
 
 export const log = logger.child({module: `${projectName}/utils/exec`});
 
@@ -41,7 +41,8 @@ export const exec = async (command, args, options) => {
     ps.on('close', (exitCode) => {
       log.info({command: `${command} ${args.join(' ')}`, stdout, stderr, exitCode, options}, 'exec command finished');
       if (exitCode !== 0 && options.noThrow === false) {
-        core.setFailed(`Failed to run command: ${command} '${args.join("', '")}'`);
+        core.warning(`Failed to run command: ${command} '${args.join("', '")}'`);
+        log.warn({command, args, options, stdout, stderr, exitCode}, 'Command failed');
       }
       resolve({stdout, stderr, exitCode});
     });

--- a/src/utils/git.js
+++ b/src/utils/git.js
@@ -162,7 +162,7 @@ export const tag = {
   },
 
   /**
-   * Test if a tag exists in the repository.
+   * Test if a tag exists locally in the repository.
    *
    * @param {string} tagName
    * @returns {Promise<boolean>}
@@ -170,6 +170,25 @@ export const tag = {
   exists: async (tagName) => {
     const {stdout} = await exec('git', ['tag', '-l', tagName]);
     return stdout.trim() === tagName;
+  },
+
+  /**
+   * Test if a tag exists on the remote repository.
+   *
+   * @param {string} tagName
+   * @param {string} [remote='origin'] - Remote name to check
+   * @returns {Promise<boolean>}
+   */
+  existsRemote: async (tagName, remote = 'origin') => {
+    try {
+      const {stdout} = await exec('git', ['ls-remote', '--tags', remote, `refs/tags/${tagName}`], {
+        noThrow: true,
+      });
+      return stdout.trim().includes(`refs/tags/${tagName}`);
+    } catch (err) {
+      log.warn({tagName, remote, err}, 'Failed to check if remote tag exists');
+      return false;
+    }
   },
 
   /**
@@ -222,11 +241,21 @@ export const tag = {
     log.info({tagName}, infoTagDeleted);
 
     // Also try to delete the tag from remote
-    await exec('git', ['fetch']);
-    const {exitCode} = await exec('git', ['push', 'origin', '--delete', tagName]);
-    if (exitCode === 0) {
-      log.info({tagName}, infoRemoteTagDeleted);
-    } else {
+    try {
+      await exec('git', ['fetch'], {noThrow: true});
+      const remoteTagExists = await tag.existsRemote(tagName);
+
+      if (remoteTagExists) {
+        const {exitCode} = await exec('git', ['push', 'origin', '--delete', tagName], {noThrow: true});
+        if (exitCode === 0) {
+          log.info({tagName}, infoRemoteTagDeleted);
+        } else {
+          log.warn({tagName}, warnCouldNotRemoveRemoteTag);
+        }
+      } else {
+        log.info({tagName}, 'Remote tag does not exist, skipping remote deletion');
+      }
+    } catch (err) {
       log.warn({tagName, err}, warnCouldNotRemoveRemoteTag);
     }
   },

--- a/src/utils/git.js
+++ b/src/utils/git.js
@@ -222,12 +222,11 @@ export const tag = {
     log.info({tagName}, infoTagDeleted);
 
     // Also try to delete the tag from remote
-    try {
-      for (const args of [['fetch'], ['push', 'origin', '--delete', tagName]]) {
-        await exec('git', args, {noThrow: true});
-      }
+    await exec('git', ['fetch']);
+    const {exitCode} = await exec('git', ['push', 'origin', '--delete', tagName]);
+    if (exitCode === 0) {
       log.info({tagName}, infoRemoteTagDeleted);
-    } catch (err) {
+    } else {
       log.warn({tagName, err}, warnCouldNotRemoveRemoteTag);
     }
   },

--- a/src/utils/git.js
+++ b/src/utils/git.js
@@ -1,7 +1,7 @@
 import path from 'node:path';
-import {logger} from './logging.js';
 import {projectName} from '../constants.js';
 import {exec} from './exec.js';
+import {logger} from './logging.js';
 
 export const log = logger.child({module: `${projectName}/utils/git`});
 
@@ -212,7 +212,7 @@ export const tag = {
   },
 
   /**
-   * Delete an existing Tag from the repository.
+   * Delete an existing Tag from the repository (both local and remote).
    *
    * @param {string} tagName
    * @returns {Promise<void>}
@@ -221,10 +221,15 @@ export const tag = {
     await exec('git', ['tag', '-d', tagName]);
     log.info({tagName}, infoTagDeleted);
 
-    // TODO: Remote tag deletion is optional and might not be necessary
-    // // Also try to delete it from remote
-    //   await exec('git', ['push', 'origin', `:refs/tags/${tagName}`]);
-    //   log.info({tagName}, infoRemoteTagDeleted);
+    // Also try to delete the tag from remote
+    try {
+      for (const args of [['fetch'], ['push', 'origin', '--delete', tagName]]) {
+        await exec('git', args, {noThrow: true});
+      }
+      log.info({tagName}, infoRemoteTagDeleted);
+    } catch (err) {
+      log.warn({tagName, err}, warnCouldNotRemoveRemoteTag);
+    }
   },
 };
 

--- a/src/utils/git.js
+++ b/src/utils/git.js
@@ -181,9 +181,7 @@ export const tag = {
    */
   existsRemote: async (tagName, remote = 'origin') => {
     try {
-      const {stdout} = await exec('git', ['ls-remote', '--tags', remote, `refs/tags/${tagName}`], {
-        noThrow: true,
-      });
+      const {stdout} = await exec('git', ['ls-remote', '--tags', remote, `refs/tags/${tagName}`]);
       return stdout.trim().includes(`refs/tags/${tagName}`);
     } catch (err) {
       log.warn({tagName, remote, err}, 'Failed to check if remote tag exists');
@@ -242,11 +240,11 @@ export const tag = {
 
     // Also try to delete the tag from remote
     try {
-      await exec('git', ['fetch'], {noThrow: true});
+      await exec('git', ['fetch']);
       const remoteTagExists = await tag.existsRemote(tagName);
 
       if (remoteTagExists) {
-        const {exitCode} = await exec('git', ['push', 'origin', '--delete', tagName], {noThrow: true});
+        const {exitCode} = await exec('git', ['push', 'origin', '--delete', tagName]);
         if (exitCode === 0) {
           log.info({tagName}, infoRemoteTagDeleted);
         } else {

--- a/src/utils/git.spec.js
+++ b/src/utils/git.spec.js
@@ -199,6 +199,41 @@ describe('utils/git.js', () => {
         });
       });
 
+      describe('existsRemote()', () => {
+        it('returns true when remote tag exists', async () => {
+          execMock.mockResolvedValueOnce({stdout: `abc123\trefs/tags/${lastTag}\n`, stderr: '', exitCode: 0});
+
+          const result = await git.tag.existsRemote(lastTag);
+          expect(execMock).toHaveBeenCalledWith('git', ['ls-remote', '--tags', 'origin', `refs/tags/${lastTag}`], {
+            noThrow: true,
+          });
+          expect(result).toBe(true);
+        });
+
+        it('returns false when remote tag does not exist', async () => {
+          execMock.mockResolvedValueOnce({stdout: '', stderr: '', exitCode: 0});
+
+          const result = await git.tag.existsRemote('v2.0.0');
+          expect(result).toBe(false);
+        });
+
+        it('returns false on error', async () => {
+          execMock.mockRejectedValueOnce(new Error('Network error'));
+
+          const result = await git.tag.existsRemote('v1.0.0');
+          expect(result).toBe(false);
+        });
+
+        it('accepts custom remote name', async () => {
+          execMock.mockResolvedValueOnce({stdout: `abc123\trefs/tags/v1.0.0\n`, stderr: '', exitCode: 0});
+
+          await git.tag.existsRemote('v1.0.0', 'upstream');
+          expect(execMock).toHaveBeenCalledWith('git', ['ls-remote', '--tags', 'upstream', 'refs/tags/v1.0.0'], {
+            noThrow: true,
+          });
+        });
+      });
+
       describe('lastCreated()', () => {
         it('returns the last created tag', async () => {
           const result = await git.tag.lastCreated();

--- a/src/utils/git.spec.js
+++ b/src/utils/git.spec.js
@@ -1,11 +1,11 @@
-import {describe, it, expect, beforeEach, vi} from 'vitest';
+import {beforeEach, describe, expect, it, vi} from 'vitest';
 
-import * as exec from './exec.js';
-import * as git from './git.js';
 import {oldVersion} from '../vitest/setup.detect-update.tests.js';
 import {removeTempProjectFolder} from '../vitest/setup.fs.test.js';
-import {mockPinoIn, unMockPinoIn, setupPinoLoggingCallsTest} from '../vitest/setup.logging.tests.js';
+import {mockPinoIn, setupPinoLoggingCallsTest, unMockPinoIn} from '../vitest/setup.logging.tests.js';
 import {createWorkspacesTestFolder, updateAndCommit} from '../vitest/setup.workspaces.tests.js';
+import * as exec from './exec.js';
+import * as git from './git.js';
 
 /**
  * TODO: As seen, not all tests use mkdtemp. Need to adapt the one that can be adapted to use mkdtemp.
@@ -176,9 +176,11 @@ describe('utils/git.js', () => {
           await git.tag.createAndPush('v1.0.0', 'Version 1.0.0');
 
           expect(execMock).toHaveBeenNthCalledWith(2, 'git', ['tag', '-d', 'v1.0.0']);
-          expect(execMock).toHaveBeenNthCalledWith(3, 'git', ['tag', '-a', 'v1.0.0', '-m', 'Version 1.0.0']);
-          expect(execMock).toHaveBeenNthCalledWith(4, 'git', ['fetch']);
-          expect(execMock).toHaveBeenNthCalledWith(5, 'git', ['push', 'origin', 'v1.0.0', '--no-verify']);
+          expect(execMock).toHaveBeenNthCalledWith(3, 'git', ['fetch'], {noThrow: true});
+          expect(execMock).toHaveBeenNthCalledWith(4, 'git', ['push', 'origin', '--delete', 'v1.0.0'], {noThrow: true});
+          expect(execMock).toHaveBeenNthCalledWith(5, 'git', ['tag', '-a', 'v1.0.0', '-m', 'Version 1.0.0']);
+          expect(execMock).toHaveBeenNthCalledWith(6, 'git', ['fetch']);
+          expect(execMock).toHaveBeenNthCalledWith(7, 'git', ['push', 'origin', 'v1.0.0', '--no-verify']);
 
           setupPinoLoggingCallsTest('info', [{tagName: 'v1.0.0'}, git.infoTagAlreadyExists], git.log);
         });
@@ -218,10 +220,36 @@ describe('utils/git.js', () => {
       });
 
       describe('remove()', () => {
-        it('removes a tag', async () => {
+        it('removes a tag locally and remotely', async () => {
+          execMock.mockResolvedValueOnce({stdout: '', stderr: '', exitCode: 0}); // For tag -d
+          execMock.mockResolvedValueOnce({stdout: '', stderr: '', exitCode: 0}); // For fetch
+          execMock.mockResolvedValueOnce({stdout: '', stderr: '', exitCode: 0}); // For push --delete
+
           await git.tag.remove(lastTag);
+
+          expect(execMock).toHaveBeenCalledTimes(3);
+          expect(execMock).toHaveBeenNthCalledWith(1, 'git', ['tag', '-d', lastTag]);
+          expect(execMock).toHaveBeenNthCalledWith(2, 'git', ['fetch'], {noThrow: true});
+          expect(execMock).toHaveBeenNthCalledWith(3, 'git', ['push', 'origin', '--delete', lastTag], {
+            noThrow: true,
+          });
+          setupPinoLoggingCallsTest('info', [{tagName: lastTag}, git.infoTagDeleted], git.log);
+          setupPinoLoggingCallsTest('info', [{tagName: lastTag}, git.infoRemoteTagDeleted], git.log);
+        });
+
+        it('handles remote tag deletion failure gracefully', async () => {
+          execMock.mockResolvedValueOnce({stdout: '', stderr: '', exitCode: 0}); // For tag -d
+          execMock.mockRejectedValueOnce(new Error('Remote tag not found')); // For fetch/push failure
+
+          await git.tag.remove(lastTag);
+
           expect(execMock).toHaveBeenCalledWith('git', ['tag', '-d', lastTag]);
           setupPinoLoggingCallsTest('info', [{tagName: lastTag}, git.infoTagDeleted], git.log);
+          setupPinoLoggingCallsTest(
+            'warn',
+            [expect.objectContaining({tagName: lastTag, err: expect.any(Error)}), git.warnCouldNotRemoveRemoteTag],
+            git.log,
+          );
         });
       });
     });

--- a/src/utils/git.spec.js
+++ b/src/utils/git.spec.js
@@ -176,8 +176,8 @@ describe('utils/git.js', () => {
           await git.tag.createAndPush('v1.0.0', 'Version 1.0.0');
 
           expect(execMock).toHaveBeenNthCalledWith(2, 'git', ['tag', '-d', 'v1.0.0']);
-          expect(execMock).toHaveBeenNthCalledWith(3, 'git', ['fetch'], {noThrow: true});
-          expect(execMock).toHaveBeenNthCalledWith(4, 'git', ['push', 'origin', '--delete', 'v1.0.0'], {noThrow: true});
+          expect(execMock).toHaveBeenNthCalledWith(3, 'git', ['fetch']);
+          expect(execMock).toHaveBeenNthCalledWith(4, 'git', ['push', 'origin', '--delete', 'v1.0.0']);
           expect(execMock).toHaveBeenNthCalledWith(5, 'git', ['tag', '-a', 'v1.0.0', '-m', 'Version 1.0.0']);
           expect(execMock).toHaveBeenNthCalledWith(6, 'git', ['fetch']);
           expect(execMock).toHaveBeenNthCalledWith(7, 'git', ['push', 'origin', 'v1.0.0', '--no-verify']);

--- a/src/utils/git.spec.js
+++ b/src/utils/git.spec.js
@@ -177,7 +177,7 @@ describe('utils/git.js', () => {
 
           expect(execMock).toHaveBeenNthCalledWith(2, 'git', ['tag', '-d', 'v1.0.0']);
           expect(execMock).toHaveBeenNthCalledWith(3, 'git', ['fetch']);
-          expect(execMock).toHaveBeenNthCalledWith(4, 'git', ['push', 'origin', '--delete', 'v1.0.0']);
+          expect(execMock).toHaveBeenNthCalledWith(4, 'git', ['ls-remote', '--tags', 'origin', 'refs/tags/v1.0.0']);
           expect(execMock).toHaveBeenNthCalledWith(5, 'git', ['tag', '-a', 'v1.0.0', '-m', 'Version 1.0.0']);
           expect(execMock).toHaveBeenNthCalledWith(6, 'git', ['fetch']);
           expect(execMock).toHaveBeenNthCalledWith(7, 'git', ['push', 'origin', 'v1.0.0', '--no-verify']);
@@ -204,9 +204,7 @@ describe('utils/git.js', () => {
           execMock.mockResolvedValueOnce({stdout: `abc123\trefs/tags/${lastTag}\n`, stderr: '', exitCode: 0});
 
           const result = await git.tag.existsRemote(lastTag);
-          expect(execMock).toHaveBeenCalledWith('git', ['ls-remote', '--tags', 'origin', `refs/tags/${lastTag}`], {
-            noThrow: true,
-          });
+          expect(execMock).toHaveBeenCalledWith('git', ['ls-remote', '--tags', 'origin', `refs/tags/${lastTag}`]);
           expect(result).toBe(true);
         });
 
@@ -228,9 +226,7 @@ describe('utils/git.js', () => {
           execMock.mockResolvedValueOnce({stdout: `abc123\trefs/tags/v1.0.0\n`, stderr: '', exitCode: 0});
 
           await git.tag.existsRemote('v1.0.0', 'upstream');
-          expect(execMock).toHaveBeenCalledWith('git', ['ls-remote', '--tags', 'upstream', 'refs/tags/v1.0.0'], {
-            noThrow: true,
-          });
+          expect(execMock).toHaveBeenCalledWith('git', ['ls-remote', '--tags', 'upstream', 'refs/tags/v1.0.0']);
         });
       });
 
@@ -255,26 +251,43 @@ describe('utils/git.js', () => {
       });
 
       describe('remove()', () => {
-        it('removes a tag locally and remotely', async () => {
+        it('removes a tag locally and remotely when remote tag exists', async () => {
           execMock.mockResolvedValueOnce({stdout: '', stderr: '', exitCode: 0}); // For tag -d
           execMock.mockResolvedValueOnce({stdout: '', stderr: '', exitCode: 0}); // For fetch
+          execMock.mockResolvedValueOnce({stdout: `abc123\trefs/tags/${lastTag}\n`, stderr: '', exitCode: 0}); // For ls-remote (existsRemote)
           execMock.mockResolvedValueOnce({stdout: '', stderr: '', exitCode: 0}); // For push --delete
+
+          await git.tag.remove(lastTag);
+
+          expect(execMock).toHaveBeenCalledTimes(4);
+          expect(execMock).toHaveBeenNthCalledWith(1, 'git', ['tag', '-d', lastTag]);
+          expect(execMock).toHaveBeenNthCalledWith(2, 'git', ['fetch']);
+          expect(execMock).toHaveBeenNthCalledWith(3, 'git', ['ls-remote', '--tags', 'origin', `refs/tags/${lastTag}`]);
+          expect(execMock).toHaveBeenNthCalledWith(4, 'git', ['push', 'origin', '--delete', lastTag]);
+          setupPinoLoggingCallsTest('info', [{tagName: lastTag}, git.infoTagDeleted], git.log);
+          setupPinoLoggingCallsTest('info', [{tagName: lastTag}, git.infoRemoteTagDeleted], git.log);
+        });
+
+        it('skips remote deletion when remote tag does not exist', async () => {
+          execMock.mockResolvedValueOnce({stdout: '', stderr: '', exitCode: 0}); // For tag -d
+          execMock.mockResolvedValueOnce({stdout: '', stderr: '', exitCode: 0}); // For fetch
+          execMock.mockResolvedValueOnce({stdout: '', stderr: '', exitCode: 0}); // For ls-remote (existsRemote returns false)
 
           await git.tag.remove(lastTag);
 
           expect(execMock).toHaveBeenCalledTimes(3);
           expect(execMock).toHaveBeenNthCalledWith(1, 'git', ['tag', '-d', lastTag]);
-          expect(execMock).toHaveBeenNthCalledWith(2, 'git', ['fetch'], {noThrow: true});
-          expect(execMock).toHaveBeenNthCalledWith(3, 'git', ['push', 'origin', '--delete', lastTag], {
-            noThrow: true,
-          });
           setupPinoLoggingCallsTest('info', [{tagName: lastTag}, git.infoTagDeleted], git.log);
-          setupPinoLoggingCallsTest('info', [{tagName: lastTag}, git.infoRemoteTagDeleted], git.log);
+          setupPinoLoggingCallsTest(
+            'info',
+            [{tagName: lastTag}, 'Remote tag does not exist, skipping remote deletion'],
+            git.log,
+          );
         });
 
         it('handles remote tag deletion failure gracefully', async () => {
           execMock.mockResolvedValueOnce({stdout: '', stderr: '', exitCode: 0}); // For tag -d
-          execMock.mockRejectedValueOnce(new Error('Remote tag not found')); // For fetch/push failure
+          execMock.mockRejectedValueOnce(new Error('Network error')); // For fetch failure
 
           await git.tag.remove(lastTag);
 
@@ -285,6 +298,18 @@ describe('utils/git.js', () => {
             [expect.objectContaining({tagName: lastTag, err: expect.any(Error)}), git.warnCouldNotRemoveRemoteTag],
             git.log,
           );
+        });
+
+        it('warns when push --delete fails', async () => {
+          execMock.mockResolvedValueOnce({stdout: '', stderr: '', exitCode: 0}); // For tag -d
+          execMock.mockResolvedValueOnce({stdout: '', stderr: '', exitCode: 0}); // For fetch
+          execMock.mockResolvedValueOnce({stdout: `abc123\trefs/tags/${lastTag}\n`, stderr: '', exitCode: 0}); // For ls-remote
+          execMock.mockResolvedValueOnce({stdout: '', stderr: 'error: failed to delete', exitCode: 1}); // For push --delete fails
+
+          await git.tag.remove(lastTag);
+
+          setupPinoLoggingCallsTest('info', [{tagName: lastTag}, git.infoTagDeleted], git.log);
+          setupPinoLoggingCallsTest('warn', [{tagName: lastTag}, git.warnCouldNotRemoveRemoteTag], git.log);
         });
       });
     });


### PR DESCRIPTION
Closing #367

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Tag deletion now removes tags from both local and remote repositories; remote failures log warnings and do not block local cleanup.

* **Behavior Change**
  * Command execution errors are reported as warnings with richer diagnostics instead of causing hard failures.
  * Added remote-existence checks to avoid unnecessary remote deletion attempts.

* **Tests**
  * Expanded tests covering remote tag checks, deletion paths, and failure handling.

* **Documentation**
  * Updated docs to reflect dual local+remote tag deletion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->